### PR TITLE
Added support for Perl without -Dusemultiplicity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,10 @@ testexc: $(TESTSDIR)/testexc.c
 testexcrun: $(TESTSDIR)/testexcrun.c
 	gcc -o $(TESTSDIR)/testexcrun $(TESTSDIR)/testexcrun.c -lscript $(LDFLAGS) $(CPPFLAGS)
 
-tests: test1 testcall testexc testexcrun
+testmul: $(TESTSDIR)/testmul.c
+	gcc -o $(TESTSDIR)/testmul $(TESTSDIR)/testmul.c -lscript $(LDFLAGS) $(CPPFLAGS)
+	
+tests: test1 testcall testexc testexcrun testmul
 	LD_LIBRARY_PATH=$(BUILD_LIBDIR) $(TESTSDIR)/test1 $(TESTSDIR)/test1.lua
 	LD_LIBRARY_PATH=$(BUILD_LIBDIR) $(TESTSDIR)/test1 $(TESTSDIR)/test1.py
 	LD_LIBRARY_PATH=$(BUILD_LIBDIR) $(TESTSDIR)/test1 $(TESTSDIR)/test1.rb
@@ -75,6 +78,7 @@ tests: test1 testcall testexc testexcrun
 	LD_LIBRARY_PATH=$(BUILD_LIBDIR) $(TESTSDIR)/testexc $(TESTSDIR)/testexc.lua
 	LD_LIBRARY_PATH=$(BUILD_LIBDIR) $(TESTSDIR)/testexc $(TESTSDIR)/testexc.py
 	LD_LIBRARY_PATH=$(BUILD_LIBDIR) $(TESTSDIR)/testexcrun $(TESTSDIR)/testexcrun.pl
+	LD_LIBRARY_PATH=$(BUILD_LIBDIR) $(TESTSDIR)/testmul $(TESTSDIR)/testmul.pl
 
 clean:
 	rm -rf build

--- a/libscript-lua/configure.ac
+++ b/libscript-lua/configure.ac
@@ -1,7 +1,7 @@
 
 AC_PREREQ(2.59)
 AC_INIT([libscript-lua], [1.0], [hisham@inf.puc-rio.br])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/libscript-lua.c])
 AC_CONFIG_HEADER([config.h])
 

--- a/libscript-perl/configure.ac
+++ b/libscript-perl/configure.ac
@@ -1,7 +1,7 @@
 
 AC_PREREQ(2.59)
 AC_INIT([libscript-perl], [1.0], [hisham@inf.puc-rio.br])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/libscript-perl.c])
 AC_CONFIG_HEADER([config.h])
 

--- a/libscript-perl/configure.ac
+++ b/libscript-perl/configure.ac
@@ -14,7 +14,7 @@ AC_PROG_CC
 
 AC_PERL_DEVEL
 
-AC_PERL_DEFINE_CHECK([usemultiplicity], , AC_MSG_ERROR([Perl was compiled without the -Dusemultiplicity flag.]))
+AC_PERL_DEFINE_CHECK([usemultiplicity], ,AC_DEFINE([P_DONT_USE_MULTIPLICITY], [1], [Perl was compiled without the -Dusemultiplicity flag.]) )
 
 #AC_CHECK_LIB([script], [script_init], , AC_MSG_ERROR([Could not find suitable LibScript library.]))
 

--- a/libscript-perl/src/libscript-perl.c
+++ b/libscript-perl/src/libscript-perl.c
@@ -29,11 +29,8 @@ script_plugin_state script_plugin_init_perl(script_env* env) {
 
    #if P_DONT_USE_MULTIPLICITY
    if(script_perl_state_exists) {
-      script_set_error_message(env, "Cannot create multiple instances of Perl. Rebuild with -Dusemultiplicity.");
+      script_set_error_message(env, "System does not support multiple instances of Perl.");
       return NULL;
-      /*TODO: A NULL return seems to trigger language error in main libscript.
-      We can hack it to check the error's message, but the error code would still be that of a language error.
-      Define the new kind of error SCRIPT_ERRMUL, and get get script_plugin_load to throw that instead.*/
    }
    #endif
 
@@ -74,13 +71,6 @@ script_plugin_state script_plugin_init_perl(script_env* env) {
 }
 
 void script_plugin_done_perl(script_perl_state state) {
-   
-   if(!state)
-      return;
-
-   /*TODO: If possible, delegate checking of state (before every plugin call) to libscript main.
-   Reduce work for the plugins, and give meaningful errors. Then maybe remove the check above.
-   */
 
    PerlInterpreter* my_perl = (PerlInterpreter*) state;
    PERL_SET_CONTEXT(my_perl);

--- a/libscript-python/configure.ac
+++ b/libscript-python/configure.ac
@@ -1,7 +1,7 @@
 
 AC_PREREQ(2.59)
 AC_INIT([libscript-python], [1.0], [hisham@inf.puc-rio.br])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/libscript-python.c])
 AC_CONFIG_HEADER([config.h])
 

--- a/libscript-ruby/configure.ac
+++ b/libscript-ruby/configure.ac
@@ -1,6 +1,6 @@
 
 AC_INIT([libscript-ruby], [1.0], [hisham@inf.puc-rio.br])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/libscript-ruby.c])
 AC_CONFIG_HEADER([config.h])
 

--- a/libscript/configure.ac
+++ b/libscript/configure.ac
@@ -1,7 +1,7 @@
 
 AC_PREREQ(2.59)
 AC_INIT([libscript], [1.0], [hisham@inf.puc-rio.br])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/libscript.c])
 AC_CONFIG_HEADER([config.h])
 

--- a/libscript/src/libscript.c
+++ b/libscript/src/libscript.c
@@ -194,7 +194,7 @@ const char* script_error_message(script_env* env) {
    case SCRIPT_ERRAPI: return "API call error";
    case SCRIPT_ERRFILE: return "File error";
    case SCRIPT_ERRFILENOTFOUND: return "File not found";
-   case SCRIPT_ERRDL: return "Plugin error";
+   case SCRIPT_ERRDL: return (env->error_message[0] ? env->error_message : "Plugin error");
    case SCRIPT_ERRDLOPEN: return "Could not open plugin"; 
    case SCRIPT_ERRDLINVALID: return "Invalid plugin";
    case SCRIPT_ERRDLCLOSE: return "Could not close plugin";

--- a/libscript/src/plugin.c
+++ b/libscript/src/plugin.c
@@ -31,7 +31,7 @@ static script_err free_plugin(script_env* env, script_plugin* plugin) {
    /* FIXME: decouple finalization of states and unloading of plugins */
    if (plugin->dlhandle) {
       done_fn = (script_plugin_done_fn) get_symbol(plugin, "done");
-      if (done_fn)
+      if (done_fn && plugin->state)
          done_fn(plugin->state);
       
       err = lt_dlclose(plugin->dlhandle);
@@ -96,7 +96,7 @@ script_plugin* script_plugin_load(script_env* env, const char* id) {
    init_fn = (script_plugin_init_fn) get_symbol(plugin, "init");
    if (!init_fn) return fail_plugin(env, plugin, SCRIPT_ERRDLINVALID);
    plugin->state = init_fn(env, env->namespace);
-   if (!plugin->state) return fail_plugin(env, plugin, SCRIPT_ERRLANG);
+   if (!plugin->state) return fail_plugin(env, plugin, SCRIPT_ERRDL);
    plugin->run = (script_plugin_run_fn) get_symbol(plugin, "run");
    if (!plugin->run) return fail_plugin(env, plugin, SCRIPT_ERRDLINVALID);
    plugin->call = (script_plugin_call_fn) get_symbol(plugin, "call");

--- a/tests/testmul.c
+++ b/tests/testmul.c
@@ -1,0 +1,47 @@
+
+#include <stdio.h>
+#include <libscript.h>
+#include <stdlib.h>
+
+
+int main(int argc, char** argv) {
+   script_env* env1, *env2;
+   int err1, err2, status_code;
+   
+   env1 = script_init("env1");
+   env2 = script_init("env2");
+   
+   if (!env1 || !env2) {
+      printf("Could not init libscript.\n");
+      exit(1);
+   }
+   err1 = script_run_file(env1, argv[1]);
+   if (err1) {
+      printf("ERROR: Could not start first instance of Perl (error %d: %s).\n", err1, script_error_message(env1));
+   }
+   err2 = script_run_file(env2, argv[1]);
+   if (err2) {
+      printf("Could not start second instance of Perl (error %d: %s).\n", err2, script_error_message(env2));
+      printf("This is natural if your system doesn't support -Dusemultiplicity.\n");
+   }
+   script_done(env1);
+   script_done(env2);
+   printf("\n\nBoth instances of Perl have been terminated.\n\n");
+   env1 = script_init("env1");
+   env2 = script_init("env2");
+   
+   if (!env1 || !env2) {
+      printf("Could not init libscript again.\n");
+      exit(1);
+   }
+   err1 = script_run_file(env1, argv[1]);
+   if (err1) {
+      printf("ERROR: Could not start first instance of Perl. (error %d: %s).\n", err1, script_error_message(env1));
+   }
+   err2 = script_run_file(env2, argv[1]);
+   if (err2) {
+      printf("Could not start second instance of Perl (error %d: %s).\n", err2, script_error_message(env2));
+      printf("This is natural if your system doesn't support -Dusemultiplicity.\n");
+   }
+   return err1;
+}

--- a/tests/testmul.pl
+++ b/tests/testmul.pl
@@ -1,0 +1,2 @@
+
+print "Greetings from a new Perl instance!\n";


### PR DESCRIPTION
libscript-perl will no longer fail to build if your system does not support -Dusemultiplicity. Systems with such a configuration will be restricted to run only one instance of Perl.
